### PR TITLE
Fix azure bug 48 - Function packets crashing with incorrect json data

### DIFF
--- a/Project-5-Space-Craft/Packets/FunctionPacket.cs
+++ b/Project-5-Space-Craft/Packets/FunctionPacket.cs
@@ -121,6 +121,14 @@ namespace Payload_Ops.Packets
         [JsonConstructor]
         public FunctionPacket(string Date, string FunctionType, string Command, string PacketCRC)
         {
+            if (string.IsNullOrWhiteSpace(Date))
+                throw new ArgumentException("Date cannot be null or empty.", nameof(Date));
+            if (string.IsNullOrWhiteSpace(FunctionType))
+                throw new ArgumentException("FunctionType cannot be null or empty.", nameof(FunctionType));
+            if (string.IsNullOrWhiteSpace(Command))
+                throw new ArgumentException("Command cannot be null or empty.", nameof(Command));
+            if (string.IsNullOrWhiteSpace(PacketCRC))
+                throw new ArgumentException("PacketCRC cannot be null or empty.", nameof(PacketCRC));
             this.Date = Date;
             this.FunctionType = FunctionType;
             this.Command = Command;

--- a/Project-5-Space-Craft/Spaceship.cs
+++ b/Project-5-Space-Craft/Spaceship.cs
@@ -79,7 +79,17 @@ namespace Payload_Ops
                 PropertyNameCaseInsensitive = true,
                 IncludeFields = true 
             };
-            FunctionPacket? packet = JsonSerializer.Deserialize<FunctionPacket>(jsonObj, options);
+            FunctionPacket? packet = null;
+            try
+            {
+                packet = JsonSerializer.Deserialize<FunctionPacket>(jsonObj, options);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Function packet was not deserialized properly due to mismatching json data");
+                Console.WriteLine(e);
+                return false;
+            }
 
             if (packet == null)
             {
@@ -97,7 +107,7 @@ namespace Payload_Ops
             this.AddFunction(function);
 
             //Logging.LogPacket(packet.GetPacketType(), "Incoming", packet.GetPacketData());
-                return true;
+            return true;
         }
 
         private void TimedEvent(object? state)


### PR DESCRIPTION
I have fixed the bugs with generating function packet objects unless all 4 json variables are acceptable