### PR TITLE
UD [136, 137, 138] Fix Integration Bugs + Increase Code Coverage

### DIFF
--- a/LinkServer/Controllers/AuthenticatorController.cs
+++ b/LinkServer/Controllers/AuthenticatorController.cs
@@ -10,11 +10,11 @@ using Uplink_Downlink;
 
 namespace LinkServer.Controllers
 {
-    [ApiController]
-    [Route("api/[controller]")]
+    [ApiController] // Uncovered line
+    [Route("api/[controller]")] // Uncovered line
     public class AuthenticatorController : ControllerBase
     {
-        private readonly AppLogger _logger;
+        private readonly AppLogger _logger; // Uncovered line
         private static readonly ConcurrentDictionary<string, short> _loginAttempts = new();
         private static readonly ConcurrentDictionary<string, bool> _authenticatedUsers = new();
 
@@ -32,7 +32,6 @@ namespace LinkServer.Controllers
         [HttpPost("login")]
         public IActionResult Login([FromBody] UserCredentials credentials)
         {
-
             if (_loginAttempts.TryGetValue(credentials.Username, out var attempts) && attempts >= 3)
             {
                 _logger.LogAuthentication(credentials.Username, success: false);

--- a/LinkServer/Filters/AuthenticatorFilter.cs
+++ b/LinkServer/Filters/AuthenticatorFilter.cs
@@ -19,8 +19,10 @@ namespace LinkServer.Filters
 
         public void OnActionExecuted(ActionExecutedContext context)
         {
-            // Do nothing after the action executes
-            // Must be here to use IActionFilter
+            // Do nothing after the action executes.
+            // Must be here to use IActionFilter.
+            // Throw bad request object result since this shouldn't be used.
+            context.Result = new BadRequestObjectResult("Something went wrong, OnActionExecuted() should not be called.");
         }
     }
 }

--- a/Uplink Downlink Tests/ControllerTests.cs
+++ b/Uplink Downlink Tests/ControllerTests.cs
@@ -51,7 +51,7 @@ namespace UD_ControllerTests
             string packet = "{\"Date\":,\"FunctionType\":\"FunctionStub\",\"Command\":\"TestingData\",\"PacketCRC\":\"some_crc_value\"}";
 
             // Act
-            var result = _uplinkController.SendUplink(packet) as OkObjectResult;
+            var result = _uplinkController.SendUplink(packet) as BadRequestObjectResult;
 
             // Assert
             Assert.IsNotNull(result);

--- a/Uplink Downlink Tests/ControllerTests.cs
+++ b/Uplink Downlink Tests/ControllerTests.cs
@@ -48,8 +48,8 @@ namespace UD_ControllerTests
         public void SendUplink_ShouldReturnFailureMessage()
         {
             // Arrange
-            string packet = "{\"Date\":,\"FunctionType\":\"FunctionStub\",\"Command\":\"TestingData\",\"PacketCRC\":\"some_crc_value\"}";
-
+            // string packet = "{\"Date\":,\"FunctionType\":\"FunctionStub\",\"Command\":\"TestingData\",\"PacketCRC\":\"some_crc_value\"}";
+            string packet = "";
             // Act
             var result = _uplinkController.SendUplink(packet) as BadRequestObjectResult;
 
@@ -98,13 +98,10 @@ namespace UD_ControllerTests
             var credentials = new UserCredentials { Username = "user1", Password = "wrongpassword" };
 
             // Act
-            var result = _controller.Login(credentials);
+            var result = _controller.Login(credentials) as UnauthorizedObjectResult;
 
-            Assert.IsInstanceOfType(result, typeof(UnauthorizedObjectResult));
-            var unauthorizedResult = result as UnauthorizedObjectResult;
-
-            Assert.IsNotNull(unauthorizedResult);
-            Assert.AreEqual("Invalid credentials.", unauthorizedResult.Value);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Invalid credentials.", result?.Value?.ToString());
         }
 
         [TestMethod]

--- a/Uplink Downlink Tests/ControllerTests.cs
+++ b/Uplink Downlink Tests/ControllerTests.cs
@@ -33,7 +33,7 @@ namespace UD_ControllerTests
         public void SendUplink_ShouldReturnSuccessMessage()
         {
             // Arrange
-            string packet = "{\"Date\":\"2024-11-07T19:26:34.0177707-05:00\",\"FunctionType\":\"FunctionStub\",\"Command\":\"TestingData\",\"PacketCRC\":\"some_crc_value\"}";
+            string packet = "{\"Date\":\"2024-11-07T19:26:34.0177707-05:00\",\"FunctionType\":\"increasethrustfunction\",\"Command\":\"8\",\"PacketCRC\":\"some_crc_value\"}";
 
 
             // Act

--- a/Uplink Downlink Tests/ControllerTests.cs
+++ b/Uplink Downlink Tests/ControllerTests.cs
@@ -44,7 +44,6 @@ namespace UD_ControllerTests
             Assert.AreEqual("Uplink processed successfully.", result?.Value?.ToString());
         }
 
-        // This will fail until PO adds the try/catch.
         [TestMethod]
         public void SendUplink_ShouldReturnFailureMessage()
         {
@@ -99,12 +98,13 @@ namespace UD_ControllerTests
             var credentials = new UserCredentials { Username = "user1", Password = "wrongpassword" };
 
             // Act
-            var result = _controller.Login(credentials) as UnauthorizedObjectResult;
+            var result = _controller.Login(credentials);
 
-            // Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Invalid credentials.", result.Value);
-            Assert.IsFalse(AuthenticatorController.IsAuthenticated("user1"));
+            Assert.IsInstanceOfType(result, typeof(UnauthorizedObjectResult));
+            var unauthorizedResult = result as UnauthorizedObjectResult;
+
+            Assert.IsNotNull(unauthorizedResult);
+            Assert.AreEqual("Invalid credentials.", unauthorizedResult.Value);
         }
 
         [TestMethod]

--- a/Uplink Downlink Tests/ControllerTests.cs
+++ b/Uplink Downlink Tests/ControllerTests.cs
@@ -105,6 +105,19 @@ namespace UD_ControllerTests
         }
 
         [TestMethod]
+        public void TestLogin_InvalidUsername()
+        {
+            // Arrange
+            var credentials = new UserCredentials { Username = "user", Password = "password1" };
+
+            // Act
+            var result = _controller.Login(credentials) as UnauthorizedObjectResult;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Invalid credentials.", result?.Value?.ToString());
+        }
+
+        [TestMethod]
         public void TestLogin_TooManyAttempts()
         {
             // Arrange

--- a/Uplink Downlink Tests/FilterTests.cs
+++ b/Uplink Downlink Tests/FilterTests.cs
@@ -1,0 +1,161 @@
+using LinkServer.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Text;
+using Xunit;
+
+namespace UD_FilterTests
+{
+    public class AuthenticateFilterTests
+    {
+        [Fact]
+        public void OnActionExecuting_ShouldReturnUnauthorized_WhenUsernameIsNotInSession()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext
+            {
+                Session = new MockSession() // Attach the mock session
+            };
+
+            // No "username" is set in the session, simulating an unauthenticated user
+
+            var routeData = new RouteData();
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = routeData,
+                ActionDescriptor = new ControllerActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                new object()
+            );
+
+            var filter = new AuthenticateFilter();
+
+            // Act
+            filter.OnActionExecuting(actionExecutingContext);
+
+            // Assert
+            var result = actionExecutingContext.Result as UnauthorizedObjectResult;
+            Xunit.Assert.NotNull(result); // Ensure the result is Unauthorized
+            Xunit.Assert.Equal("User is not authenticated.", result.Value); // Check the error message
+        }
+
+        [Fact]
+        public void OnActionExecuting_ShouldAllowRequest_WhenUsernameIsInSession()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext
+            {
+                Session = new MockSession() // Attach the mock session
+            };
+
+            // Add "username" to the session to simulate an authenticated user
+            httpContext.Session.SetString("username", "user1");
+
+            var routeData = new RouteData();
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = routeData,
+                ActionDescriptor = new ControllerActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                new object()
+            );
+
+            var filter = new AuthenticateFilter();
+
+            // Act
+            filter.OnActionExecuting(actionExecutingContext);
+
+            // Assert
+            Xunit.Assert.Null(actionExecutingContext.Result); // Ensure the Result is null (no interruption)
+        }
+
+        [Fact]
+        public void OnActionExecuted_ShouldReturnBadRequest_WhenConditionIsMet()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext
+            {
+                Session = new MockSession() // Attach the mock session
+            };
+
+            var routeData = new RouteData();
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = routeData,
+                ActionDescriptor = new ControllerActionDescriptor()
+            };
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new object()
+            );
+
+            var filter = new AuthenticateFilter();
+
+            // Act
+            filter.OnActionExecuted(actionExecutedContext);
+
+            // Assert
+            var result = actionExecutedContext.Result as BadRequestObjectResult;
+            Xunit.Assert.NotNull(result); // Ensure the result is BadRequest
+            Xunit.Assert.Equal("Something went wrong, OnActionExecuted() should not be called.", result.Value); // Check the error message
+        }
+
+        public class MockSession : ISession
+        {
+            private readonly Dictionary<string, byte[]> _sessionStorage = new();
+
+            public IEnumerable<string> Keys => _sessionStorage.Keys;
+
+            public string Id => Guid.NewGuid().ToString();
+
+            public bool IsAvailable => true;
+
+            public void Clear() => _sessionStorage.Clear();
+
+            public void Remove(string key) => _sessionStorage.Remove(key);
+
+            public void Set(string key, byte[] value) => _sessionStorage[key] = value;
+
+            public bool TryGetValue(string key, out byte[] value) => _sessionStorage.TryGetValue(key, out value);
+
+            public void SetString(string key, string value) =>
+                Set(key, System.Text.Encoding.UTF8.GetBytes(value));
+
+            public string? GetString(string key)
+            {
+                return TryGetValue(key, out var value) ? System.Text.Encoding.UTF8.GetString(value) : null;
+            }
+
+            public Task LoadAsync(CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task CommitAsync(CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+    }


### PR DESCRIPTION
I have made various fixed at improving code quality for the server as we continue integrating:

Issue 136:
- Updated the object types that are returned to properly check for the false that the PO Receive function calls

Issue 137:
- Added a check that the object that is returned is an UnauthorizedObjectResult rather than checking a local variable inside of the AuthenticatorController

Issue 138:
- I have increased code coverage for the AuthenticatorFilter (wasn't tested at all) and the AuthenticatorController (wasn't testing wrong username)

I also installed XUnit in our test project which was needed to properly test the filter(s).

Code coverage is now at 100% for server (except the Program.cs which should be integration tested and functionally tested).
![image](https://github.com/user-attachments/assets/eda16cb1-cd40-4711-905d-40c5498ec466)
